### PR TITLE
fix: update package-lock.json in changesets release PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@v1
         with:
+          version: npm run changeset-version
           publish: npm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "lint": "oxlint src test",
     "test": "NODE_ENV=test mocha",
     "build": "tsdown",
+    "changeset-version": "changeset version && npm install --package-lock-only",
     "release": "npm run build && changeset publish",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
Add a custom version script that runs `npm install --package-lock-only` after `changeset version`, so the lockfile stays in sync in the Version Packages PR.