### PR TITLE
fix: add async generator support to Definition type

### DIFF
--- a/.changeset/fix-definition-type.md
+++ b/.changeset/fix-definition-type.md
@@ -1,0 +1,5 @@
+---
+'@robinvdbroeck/factory-girl': patch
+---
+
+Add `(() => Promise<T>)` to the `Definition<T>` type to support async generators like `factory.assoc()`

--- a/src/FactoryGirl.ts
+++ b/src/FactoryGirl.ts
@@ -7,7 +7,7 @@ const chance = new Chance();
 
 // Public type exports
 export type Generator<T = any> = () => T;
-export type Definition<T = any> = T | Generator<T> | Promise<T>;
+export type Definition<T = any> = T | Generator<T> | Promise<T> | (() => Promise<T>);
 export type Attributes<T = any> = { [P in keyof T]: Definition<T[P]> };
 export type MaybeReadonlyArray<T = any> = T | readonly T[];
 export type BuildOptions = Record<string, any>;


### PR DESCRIPTION
The Definition<T> type was missing (() => Promise<T>), causing type errors when using factory.assoc() in typed definitions. The runtime already handles this via asyncPopulate.