### PR TITLE
ci: use node 24 for releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - run: npm ci


### PR DESCRIPTION
Node 24 uses npm 11 which supports trusted publishing.