### PR TITLE
ci: fix git url

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/robinvdbroeck/factory-girl.git"
+    "url": "git+ssh://git@github.com/RobinVdBroeck/factory-girl.git"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Trusted publishing is case sensitive for URL